### PR TITLE
Some, mostly automated, code cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,11 @@
-import os
-
-from click import get_app_dir
-import decky_plugin
-from pathlib import Path
+import asyncio
 import json
 import os
-import subprocess
-import sys
 import shutil
 import time
-import asyncio
+from pathlib import Path
+
+import decky_plugin
 
 
 class Plugin:

--- a/main.py
+++ b/main.py
@@ -94,7 +94,6 @@ class Plugin:
             return False
 
     async def sdsa_classic(self):
-        id_map = self._id_map
         path = Path.home() / ".local/share/Steam/userdata"
         files = list(path.glob("**/screenshots/*.jpg"))
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,12 +23,15 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
     setButtonEnabled(false);
     setFeedbackText("Aggregating...");
     let store: any = window.appStore;
-    const result = await serverAPI.callPluginMethod(
-      "aggregate_all", { allapps: store.allApps.map((i: any) => [i.appid, i.display_name])});
+    const result = await serverAPI.callPluginMethod("aggregate_all", {
+      allapps: store.allApps.map((i: any) => [i.appid, i.display_name]),
+    });
     if (result.result >= 0) {
       setFeedbackText("Copied " + result.result + " files");
     } else {
-      setFeedbackText("Something went wrong during aggregation. Please check logs.");
+      setFeedbackText(
+        "Something went wrong during aggregation. Please check logs.",
+      );
     }
     setButtonEnabled(true);
   };
@@ -39,7 +42,9 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
   return (
     <PanelSection title="Panel Section">
       <PanelSectionRow>
-        <ButtonItem layout="below" onClick={onClick} disabled={!buttonEnabled}>Aggregate!</ButtonItem>
+        <ButtonItem layout="below" onClick={onClick} disabled={!buttonEnabled}>
+          Aggregate!
+        </ButtonItem>
       </PanelSectionRow>
       <PanelSectionRow>
         <div>{feedbackText}</div>
@@ -50,19 +55,27 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
 
 export default definePlugin((serverApi: ServerAPI) => {
   let store: any = window.appStore;
-  serverApi.callPluginMethod("set_id_map_fronend", {allapps: store.allApps.map((i: any) => [i.appid, i.display_name])});
-  let screenshot_register = window.SteamClient.GameSessions.RegisterForScreenshotNotification(async (data: any) => {
-    console.log(data);
-    let res = await serverApi.callPluginMethod("copy_screenshot", { app_id: data.unAppID, url: data.details.strUrl});
-    if (!res.result) {
-      await serverApi.toaster.toast({
-        title: "Shotty",
-        body: "Failed to symlink screenshot",
-        duration: 1000,
-        critical: true
-      })
-    }
+  serverApi.callPluginMethod("set_id_map_fronend", {
+    allapps: store.allApps.map((i: any) => [i.appid, i.display_name]),
   });
+  let screenshot_register =
+    window.SteamClient.GameSessions.RegisterForScreenshotNotification(
+      async (data: any) => {
+        console.log(data);
+        let res = await serverApi.callPluginMethod("copy_screenshot", {
+          app_id: data.unAppID,
+          url: data.details.strUrl,
+        });
+        if (!res.result) {
+          await serverApi.toaster.toast({
+            title: "Shotty",
+            body: "Failed to symlink screenshot",
+            duration: 1000,
+            critical: true,
+          });
+        }
+      },
+    );
 
   return {
     title: <div className={staticClasses.Title}>Screentshot Aggregator</div>,


### PR DESCRIPTION
I cloned the whole decky-plugin-database to audit the code, do with these as you see fit!

The .tsx changes are just the result of running `prettier -w src/`, which I believe is what's being used upstream in Decky. If you'd rather skip these or run the tool yourself I don't mind!