### PR TITLE
Update decky-frontend-lib to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "Shotty": "link:",
-    "decky-frontend-lib": "^3.24.1",
+    "decky-frontend-lib": "^3.24.5",
     "react-icons": "^4.4.0"
   },
   "pnpm": {


### PR DESCRIPTION
As explained in https://github.com/SteamDeckHomebrew/decky-frontend-lib/issues/101, a more recent frontend lib version is required to fix the console log spamming.

Built and tested on LCD 3.5.17 & Decky 2.11.1. Still functions as expected.

I didn't include `pnpm-lock.yaml` changes in pr, just fyi.